### PR TITLE
Implement background Excel processing with tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = main

--- a/appsmith_settings.md
+++ b/appsmith_settings.md
@@ -1,0 +1,9 @@
+# Appsmith Configuration
+
+1. Drag a **FilePicker** widget onto the canvas and enable multiple file upload.
+2. Set the **onFilesSelected** action to call the `/process` API with the
+   selected files.
+3. Display the returned `job_id` and poll `/results/{{job_id}}` to enable the
+   download button once the API responds with the Excel workbook.
+4. Use a **Button** widget to fetch `/results/{{job_id}}` and trigger the file
+   download when available.

--- a/main.py
+++ b/main.py
@@ -1,60 +1,136 @@
-from fastapi import FastAPI, File, UploadFile, HTTPException
-import json
-import csv
+from __future__ import annotations
+
+import asyncio
 import io
-import zipfile
+import uuid
+from datetime import date
+from typing import Dict, List, Tuple
 
-
-from extractor import extract_values, _normalize
+import pandas as pd
+from fastapi import BackgroundTasks, FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse, StreamingResponse
+from openpyxl import Workbook
 
 app = FastAPI()
 
-async def load_data(upload_file: UploadFile):
-    content = await upload_file.read()
+jobs: Dict[str, Dict[str, object]] = {}
 
-    def parse_text(text: str):
-        """Parse a JSON or CSV text block into records."""
-        # First attempt to parse JSON
-        try:
-            data = json.loads(text)
-            if isinstance(data, dict):
-                data = [data]
-            return data
-        except json.JSONDecodeError:
-            pass
 
-        # Fallback to CSV with delimiter detection
-        sample = text[:1024]
-        try:
-            dialect = csv.Sniffer().sniff(sample)
-        except csv.Error:
-            dialect = csv.excel
-        reader = csv.DictReader(io.StringIO(text), dialect=dialect)
-        rows = []
-        for row in reader:
-            clean = {_normalize(k): v for k, v in row.items()}
-            rows.append(clean)
-        return rows
-
-    # Handle ZIP archives containing CSVs (use the first CSV file found)
-    if zipfile.is_zipfile(io.BytesIO(content)):
-        with zipfile.ZipFile(io.BytesIO(content)) as zf:
-            csv_files = [n for n in zf.namelist() if n.lower().endswith('.csv')]
-            if not csv_files:
-                raise HTTPException(status_code=400, detail="No CSV files in archive")
-            text = zf.read(csv_files[0]).decode('utf-8-sig')
-        return parse_text(text)
-
-    # Regular text file
+async def parse_excel(data: bytes) -> Tuple[Dict[str, float | None], List[str]]:
+    """Extract Voc, Jsc and FF from an Excel file."""
     try:
-        text = content.decode('utf-8-sig')
-    except UnicodeDecodeError:
-        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
+        df = await asyncio.to_thread(
+            pd.read_excel,
+            io.BytesIO(data),
+            engine="openpyxl",
+            sheet_name=0,
+            usecols=["Voc", "Jsc", "FF"],
+        )
+    except Exception as exc:  # pragma: no cover - pandas raises many variants
+        return {"Voc": None, "Jsc": None, "FF": None}, [str(exc)]
 
-    return parse_text(text)
+    result: Dict[str, float | None] = {}
+    errors: List[str] = []
+    for col in ["Voc", "Jsc", "FF"]:
+        value = None
+        if col in df.columns and not df[col].dropna().empty:
+            value = df[col].dropna().iloc[0]
+        try:
+            result[col] = float(value)
+        except (TypeError, ValueError):
+            result[col] = None
+            errors.append(f"{col} invalid")
+    return result, errors
 
-@app.post("/extract")
-async def extract(file: UploadFile = File(...)):
-    data = await load_data(file)
-    result = extract_values(data)
-    return result
+
+def create_workbook(
+    values: Dict[Tuple[str, int], Dict[str, float | None]], dates: List[str]
+) -> Workbook:
+    """Create output workbook from parsed values."""
+    metrics = ["Voc", "Jsc", "FF"]
+    wb = Workbook()
+    ws = wb.active
+    col = 1
+    for metric in metrics:
+        start_col = col
+        for dt in dates:
+            ws.cell(row=2, column=col, value=dt)
+            col += 1
+        end_col = col - 1
+        ws.merge_cells(start_row=1, start_column=start_col, end_row=1, end_column=end_col)
+        ws.cell(row=1, column=start_col, value=metric)
+
+    device_rows: Dict[str, int] = {}
+    base_row = 3
+    for device, idx in sorted(values):
+        if device not in device_rows:
+            device_rows[device] = base_row
+            base_row += 4
+        row = device_rows[device] + idx - 1
+        for m_i, metric in enumerate(metrics):
+            for d_i, _ in enumerate(dates):
+                col = m_i * len(dates) + d_i + 1
+                ws.cell(row=row, column=col, value=values[(device, idx)].get(metric))
+    return wb
+
+
+async def process_files(job_id: str, uploaded: List[Tuple[str, bytes]]) -> None:
+    """Background task to parse files and build result workbook."""
+    jobs[job_id] = {"status": "processing"}
+    values: Dict[Tuple[str, int], Dict[str, float | None]] = {}
+    all_errors: List[str] = []
+    for name, data in uploaded:
+        try:
+            device, idx_str = name.rsplit("-", 1)
+            idx = int(idx_str.split(".")[0])
+        except ValueError:
+            all_errors.append(f"Invalid filename: {name}")
+            continue
+        metrics, errs = await parse_excel(data)
+        values[(device, idx)] = metrics
+        all_errors.extend(errs)
+    wb = await asyncio.to_thread(
+        create_workbook, values, [date.today().isoformat()]
+    )
+    buf = io.BytesIO()
+    await asyncio.to_thread(wb.save, buf)
+    buf.seek(0)
+    jobs[job_id] = {"status": "ready", "buffer": buf, "errors": all_errors}
+
+
+@app.post(
+    "/process",
+    summary="Upload multiple Excel files",
+    response_description="Job identifier",
+)
+async def process(  # noqa: D401 - FastAPI handles docstring
+    background_tasks: BackgroundTasks,
+    files: List[UploadFile] = File(
+        ..., description="Excel files", openapi_extra={"examples": {"file": {"filename": "101-1.xlsx"}}}
+    ),
+):
+    uploaded: List[Tuple[str, bytes]] = []
+    for f in files:
+        uploaded.append((f.filename, await f.read()))
+    job_id = str(uuid.uuid4())
+    background_tasks.add_task(process_files, job_id, uploaded)
+    return {"job_id": job_id}
+
+
+@app.get("/results/{job_id}")
+async def get_results(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Unknown job")
+    if job["status"] != "ready":
+        return JSONResponse({"status": "processing"})
+    buf: io.BytesIO = job["buffer"]
+    buf.seek(0)
+    headers = {
+        "Content-Disposition": f"attachment; filename=result_{job_id}.xlsx"
+    }
+    return StreamingResponse(
+        buf,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers=headers,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
-fastapi
-uvicorn
-python-multipart
+fastapi==0.110.0
+uvicorn==0.22.0
+python-multipart==0.0.7
+pandas==2.3.0
+openpyxl==3.1.2
+httpx==0.27.0
+pytest==8.2.0
+pytest-cov==4.1.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import io
+import asyncio
+from datetime import date
+
+import pandas as pd
+import pytest
+from openpyxl import load_workbook
+from fastapi.testclient import TestClient
+
+from main import app, create_workbook, parse_excel, jobs
+
+
+def make_excel(voc=1.1, jsc=2.2, ff=0.9) -> bytes:
+    df = pd.DataFrame({"Voc": [voc], "Jsc": [jsc], "FF": [ff]})
+    buf = io.BytesIO()
+    df.to_excel(buf, engine="openpyxl", index=False)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_parse_and_workbook():
+    data = make_excel(1.23, 4.56, 0.78)
+    values, errors = asyncio.run(parse_excel(data))
+    assert values == {"Voc": 1.23, "Jsc": 4.56, "FF": 0.78}
+    assert not errors
+    wb = create_workbook({("101", 1): values}, [date.today().isoformat()])
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    loaded = load_workbook(buf)
+    ws = loaded.active
+    assert ws.cell(row=3, column=1).value == 1.23
+    assert ws.cell(row=3, column=2).value == 4.56
+    assert ws.cell(row=3, column=3).value == 0.78
+
+
+def test_numeric_validation():
+    data = make_excel("bad", 1, 2)
+    values, errors = asyncio.run(parse_excel(data))
+    assert values["Voc"] is None
+    assert errors
+
+def test_endpoints():
+    client = TestClient(app)
+    data = make_excel(0.5, 1.1, 0.9)
+    files = {"files": ("101-1.xlsx", data, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")}
+    res = client.post("/process", files=files)
+    assert res.status_code == 200
+    job_id = res.json()["job_id"]
+    # wait for background task
+    for _ in range(5):
+        resp = client.get(f"/results/{job_id}")
+        if resp.status_code == 200:
+            break
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    ws = wb.active
+    assert ws.cell(row=3, column=1).value == 0.5


### PR DESCRIPTION
## Summary
- add async Excel-processing FastAPI app
- pin package versions
- document Appsmith setup
- provide unit tests with coverage

## Testing
- `pytest -q --cov=main`

------
https://chatgpt.com/codex/tasks/task_e_688b19d56bb883219ced7a85b6aa9a37